### PR TITLE
Add opencv3_catkin as a dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,4 +10,6 @@
   <buildtool_depend>catkin</buildtool_depend>
   <buildtool_depend>catkin_simple</buildtool_depend>
 
+  <depend>opencv3_catkin</depend>
+
 </package>


### PR DESCRIPTION
Kimera-VIO requires opencv3, and Kimera-VIO-ROS includes the [opencv3_catkin](https://github.com/ethz-asl/opencv3_catkin) package in its `package.xml`. However, on some machines building `dbow2_catkin` will cause the DBoW2 library to automatically link with the system-wide opencv3.2.0.

This PR explicitly adds the dependency on the opencv3 catkin wrapper.