### PR TITLE
remove GIT_PROGRESS to allow build on xenial (ubuntu 14.04)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
 ExternalProject_Add(dbow2_src
   GIT_REPOSITORY https://github.com/dorian3d/DBoW2.git
   GIT_TAG origin/master
-  GIT_PROGRESS 1
   UPDATE_COMMAND ""
   #PATCH_COMMAND ""
   CONFIGURE_COMMAND cd ../dbow2_src && cmake -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
Hi Marcus,
The GIT_PROGRESS is not supported on older git versions which breaks the kimera-ros build on Ubuntu 14.04.
I'm currently trying to get a clean build on Ubuntu 16, 18, 20, and this is the only show stopper for Ubuntu 16.

Other people have also commented that this would be worthwhile fixing (even though 16.04 may be getting dated): https://github.com/MIT-SPARK/Kimera-VIO-ROS/issues/19

There is some similarity to PR #4  but in contrast to #4, the change of the present PR should only affect the console output.

Thanks!
